### PR TITLE
Clean Up Neuvector Docker Images Added the deleteDockerImagesByLabelKey method

### DIFF
--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -317,4 +317,11 @@ public class Scanner
         return message.replace(credential, "******");
     }
 
+    public static String deleteDockerImagesByLabelKey(String label) {
+        String errorMessage = "";
+        String[] cmdArgsDockerDelete = {"docker", "image", "prune", "--force", "--filter=label=".concat(label)};
+        errorMessage = runCMD(cmdArgsDockerDelete);
+        return errorMessage;
+    }
+
 }


### PR DESCRIPTION
We need to clean up the Neuvector Docker images, so we created this method for this purpose.