### PR TITLE
Remote Public Image scans without credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.neuvector</groupId>
   <artifactId>scanner</artifactId>
-  <version>1.7</version>
+  <version>1.8</version>
   <packaging>jar</packaging>
 
   <name>NeuVector Scanner API</name>

--- a/src/main/java/com/neuvector/Scanner.java
+++ b/src/main/java/com/neuvector/Scanner.java
@@ -54,11 +54,23 @@ public class Scanner
         }else{
             String[] credentials = {registry.getLoginPassword(), license};
             if( scanLayers ) {
-                String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
-                reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
+                if (registry.getLoginUser() == null && registry.getLoginPassword() == null) {
+                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
+                }
+                else {
+                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , "-e", "SCANNER_SCAN_LAYERS=true", getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
+                }
             }else {
-                String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
-                reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
+                if (registry.getLoginUser() == null && registry.getLoginPassword() == null) {
+                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
+                }
+                else {
+                    String[] cmdArgs = {"docker", "run", "--name", generateScannerName(), "--rm", "-v", Scanner.SOCKET_MAPPING, "-v", getMountPath(nvScanner), "-e", "SCANNER_REPOSITORY=" + registry.getRepository(), "-e", "SCANNER_TAG=" + registry.getRepositoryTag(), "-e", "SCANNER_LICENSE=" + license, "-e", "SCANNER_REGISTRY=" + registry.getRegistryURL(), "-e", "SCANNER_REGISTRY_USERNAME=" + registry.getLoginUser(), "-e", "SCANNER_REGISTRY_PASSWORD=" + registry.getLoginPassword() , getNVImagePath(nvScanner.getNvScannerImage(), nvScanner.getNvRegistryURL())};
+                    reportData = runScan(cmdArgs, nvScanner.getNvMountPath(), credentials);
+                }
             }
 
         }
@@ -146,7 +158,7 @@ public class Scanner
             return errorMessage;
         }
 
-        if(nvRegistryUser != "" && nvRegistryPassword != ""){
+        if(!nvRegistryUser.equals("") && !nvRegistryPassword.equals("")){
             String[] cmdArgsDockerLogin = {"docker", "login", "-u", nvRegistryUser, "-p", nvRegistryPassword, nvRegistryURL};
             errorMessage = runCMD(cmdArgsDockerLogin);
             if(errorMessage.length() == 0){


### PR DESCRIPTION
This change allows remote public images to be scanned without the `NEXUS_CONTAINER_IMAGE_REGISTRY_USER` and `NEXUS_CONTAINER_IMAGE_REGISTRY_PASSWORD` being provided. In other words, scanning a container with:

```
java -jar nexus-iq-cli.jar -i app-name -t build -a admin:admin -s https://test.iq.sonatype.dev container:http://registry.hub.docker.com/koraytugay/my-docker-image
```

will be successful without any environmental variables to be provided, given `koraytugay/my-docker-image` is a public image. 

Prior to this, even if the image was public, `NEXUS_CONTAINER_IMAGE_REGISTRY_USER` and `NEXUS_CONTAINER_IMAGE_REGISTRY_PASSWORD` and were required because they were always being passed to the neuvector scanner container - and neuvector scanner was trying a login with empty values. 

If the values are not provided at all, image is being downloaded without a login attempt. 